### PR TITLE
feat:ITC-14 update previsit > start sub-step

### DIFF
--- a/__tests__/features/accessibility.steps.ts
+++ b/__tests__/features/accessibility.steps.ts
@@ -18,7 +18,7 @@ const testAccessibility = (
 
     then("the page should have a descriptive title", async () => {
       await expect(browser!.getTitle()).resolves.toEqual(
-        `${pageTitle} - THC - Manage a tenancy`
+        `${pageTitle} - Introductory Tenancy Visit - Manage a tenancy`
       );
     });
   });
@@ -34,7 +34,7 @@ defineFeature(loadFeature("./accessibility.feature"), (test) => {
 
     then("the page should have a descriptive title", async () => {
       await expect(browser!.getTitle()).resolves.toEqual(
-        "Loading - THC - Manage a tenancy"
+        "Loading - Introductory Tenancy Visit - Manage a tenancy"
       );
     });
   });
@@ -47,7 +47,7 @@ defineFeature(loadFeature("./accessibility.feature"), (test) => {
 
     then("the page should have a descriptive title", async () => {
       await expect(browser!.getTitle()).resolves.toEqual(
-        "Loading - THC - Manage a tenancy"
+        "Loading - Introductory Tenancy Visit - Manage a tenancy"
       );
     });
   });

--- a/layouts/MainLayout.tsx
+++ b/layouts/MainLayout.tsx
@@ -42,7 +42,9 @@ const MainLayout = ({
 }: Props): React.ReactElement => {
   const router = useRouter();
 
-  const fullTitle = `${title || heading} - THC - Manage a tenancy`;
+  const fullTitle = `${
+    title || heading
+  } - Introductory Tenancy Visit - Manage a tenancy`;
 
   const { href, as } = urlsForRouter(
     router,

--- a/steps/previsit/start.tsx
+++ b/steps/previsit/start.tsx
@@ -56,17 +56,7 @@ const step = {
           key: "paragraph-2",
           Component: Paragraph,
           props: {
-            children:
-              "Housing Services carry out unannounced visits at tenants' homes.",
-          },
-        })
-      ),
-      ComponentWrapper.wrapStatic(
-        new StaticComponent({
-          key: "paragraph-3",
-          Component: Paragraph,
-          props: {
-            children: "The information we collect from our visits helps us to:",
+            children: "The purpose of this Introductory Tenancy Visit is",
           },
         })
       ),
@@ -76,9 +66,9 @@ const step = {
           Component: List,
           props: {
             items: [
-              "maintain up-to-date records of who lives at a property",
-              "ensure properties are being maintained",
-              "and identify any support needs.",
+              "to check you've moved into the property OK",
+              "to check that there are no outstanding repairs",
+              "to see if you have any queries about your tenancy or the estate",
             ],
             type: ListTypes.Bullet,
           } as ListProps,
@@ -90,7 +80,7 @@ const step = {
           Component: Paragraph,
           props: {
             children:
-              "We can also give advice about any tenancy issues or other enquiries.",
+              "I'll be checking your proof of ID and making sure you understand the conditions of your tenancy.",
           },
         })
       ),

--- a/steps/previsit/start.tsx
+++ b/steps/previsit/start.tsx
@@ -11,7 +11,6 @@ import {
   StaticComponent,
 } from "remultiform/component-wrapper";
 import { makeSubmit } from "../../components/makeSubmit";
-import { makeUnableToEnterSubmit } from "../../components/makeUnableToEnterSubmit";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -22,7 +21,7 @@ const step = {
     slug: PageSlugs.Start,
     nextSlug: PageSlugs.Sections,
     submit: (nextSlug?: string): ReturnType<typeof makeSubmit> =>
-      makeUnableToEnterSubmit({
+      makeSubmit({
         slug: nextSlug as PageSlugs | undefined,
         value: "Start visit with tenant",
       }),

--- a/steps/previsit/start.tsx
+++ b/steps/previsit/start.tsx
@@ -17,10 +17,10 @@ import PageTitles from "../PageTitles";
 
 const step = {
   title: PageTitles.Start,
-  heading: "Start Tenancy and Household Check",
+  heading: "Start Introductory Tenancy Visit",
   step: {
     slug: PageSlugs.Start,
-    //nextSlug: PageSlugs.AboutVisit, // TODO: change to the real next page
+    nextSlug: PageSlugs.Sections,
     submit: (nextSlug?: string): ReturnType<typeof makeSubmit> =>
       makeUnableToEnterSubmit({
         slug: nextSlug as PageSlugs | undefined,
@@ -33,7 +33,7 @@ const step = {
           Component: Heading,
           props: {
             level: HeadingLevels.H2,
-            children: "About Tenancy and Household Check",
+            children: "About Introductory Tenancy Visit",
           },
         })
       ),


### PR DESCRIPTION
ITC-14 update previsit start sub-step


# What?

- Updated the previsit > "start" sub-step heading and `<title>` copy
- Updated the `MainLayout` title to replace "THC" with "Introductory Tenancy Visit" and the accessibility tests that rely on that change

![image](https://user-images.githubusercontent.com/64883/89041247-f6c7a900-d33c-11ea-8d2c-8087a8761263.png)

# Why?

ITC-14

The copy needs to match this product

# Notes

Because of the API outages, we cannot navigate to this page without breaking some logic earlier on in the user journey.

# Next steps

<!--
  Is there any follow up work that needs to be done?

  Consider using a checklist, for example:

  - [ ] do something
  - [ ] do something else
  -->
