### PR TITLE
feat: ITV-15 update section index page

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:unit:watch": "npm run test:unit -- --watch",
     "test:feature": "PORT=3001 concurrently --names 'server,test' 'npm run test:feature:server' 'npm run test:feature:run' --kill-others --success first",
     "test:feature:update": "PORT=3001 concurrently --names 'server,test' 'npm run test:feature:server' 'npm run test:feature:run -- --updateSnapshot' --kill-others --success first",
-    "test:feature:server": "export NEXT_DIST_DIR=.next-test && export DISABLE_MAT_PROCESS_ACTIONS=1 && export ENVIRONMENT_NAME=test && export PROCESS_NAME=thc && export WORKTRAY_URL=https://work.tray && export TENANCY_URL=https://tenancy.management && export DIVERSITY_FORM_URL=https://diversity.form && export FEEDBACK_FORM_URL=https://feedback.form && npm run build && npm start",
+    "test:feature:server": "export NEXT_DIST_DIR=.next-test && export DISABLE_MAT_PROCESS_ACTIONS=1 && export ENVIRONMENT_NAME=test && export PROCESS_NAME=itv && export WORKTRAY_URL=https://work.tray && export TENANCY_URL=https://tenancy.management && export DIVERSITY_FORM_URL=https://diversity.form && export FEEDBACK_FORM_URL=https://feedback.form && npm run build && npm start",
     "test:feature:run": "wait-for-localhost ${PORT:-3000} && jest --config jest.config.feature.js --runInBand",
     "lint": "eslint --report-unused-disable-directives --config ./.eslintrc.full.js '**/*.{js,jsx,ts,tsx}'",
     "lint:fix": "npm run lint -- --fix",

--- a/pages/itv/[processRef]/loading.tsx
+++ b/pages/itv/[processRef]/loading.tsx
@@ -529,7 +529,7 @@ export const LoadingPage: NextPage = () => {
         </ErrorMessage>
       )}
 
-      <Heading level={HeadingLevels.H2}>Loading</Heading>
+      {loading && <Heading level={HeadingLevels.H2}>Loading</Heading>}
       <Paragraph>
         {isInManagerStage || isInClosedStage
           ? "The system is fetching the information you need for this process."

--- a/pages/itv/[processRef]/sections.tsx
+++ b/pages/itv/[processRef]/sections.tsx
@@ -367,7 +367,7 @@ export const SectionsPage: NextPage = () => {
   return (
     <MainLayout
       title={PageTitles.Sections}
-      heading="Tenancy and Household Check"
+      heading="Introductory Tenancy Visit"
       pausable
     >
       <TenancySummary

--- a/pages/itv/[processRef]/sections.tsx
+++ b/pages/itv/[processRef]/sections.tsx
@@ -408,7 +408,7 @@ export const SectionsPage: NextPage = () => {
           <TaskList
             items={[
               {
-                name: "ID, residency, and tenant information",
+                name: "ID  and tenant information",
                 url: urlObjectForSlug(router, PageSlugs.PresentForCheck),
                 status: idAndResidencyStatus.status,
               },


### PR DESCRIPTION
ITV-15 update section index page

# What?

- Updated the section index heading and `<title>` copy
- Fixed the loading issue on the "loading" page which showed the "Loading" headline even after the page had fully loaded
- Fixed an env var `PROCESS_NAME` for the `test:feature:server` script

![image](https://user-images.githubusercontent.com/64883/89046203-8cb30200-d344-11ea-99d6-eba60be7b0c8.png)


# Why?

ITV-15

The copy needs to match this product

# Notes

<!--
  Is there anything about the implementation worth calling out to reviewers?
  -->

# Next steps

<!--
  Is there any follow up work that needs to be done?

  Consider using a checklist, for example:

  - [ ] do something
  - [ ] do something else
  -->
