### PR TITLE
feat: ITV-31 improve the labels for each garden sub-step question

### DIFF
--- a/steps/property-inspection/garden.tsx
+++ b/steps/property-inspection/garden.tsx
@@ -1,4 +1,8 @@
-import { FieldsetLegend } from "lbh-frontend-react/components";
+import {
+  FieldsetLegend,
+  Heading,
+  HeadingLevels,
+} from "lbh-frontend-react/components";
 import React from "react";
 import {
   ComponentDatabaseMap,
@@ -107,7 +111,11 @@ const step: ProcessStepDefinition<ProcessDatabaseSchema, "property"> = {
           props: {
             name: "has-garden",
             legend: (
-              <FieldsetLegend>{questions["has-garden"]}</FieldsetLegend>
+              <FieldsetLegend>
+                <Heading level={HeadingLevels.H2}>
+                  {questions["has-garden"]}
+                </Heading>
+              </FieldsetLegend>
             ) as React.ReactNode,
             radios: yesNoRadios,
           },
@@ -130,7 +138,11 @@ const step: ProcessStepDefinition<ProcessDatabaseSchema, "property"> = {
           props: {
             name: "garden-type",
             legend: (
-              <FieldsetLegend>{questions["garden-type"]}</FieldsetLegend>
+              <FieldsetLegend>
+                <Heading level={HeadingLevels.H3}>
+                  {questions["garden-type"]}
+                </Heading>
+              </FieldsetLegend>
             ) as React.ReactNode,
             radios: gardenTypeRadios,
           },
@@ -158,7 +170,11 @@ const step: ProcessStepDefinition<ProcessDatabaseSchema, "property"> = {
           props: {
             name: "is-maintained",
             legend: (
-              <FieldsetLegend>{questions["is-maintained"]}</FieldsetLegend>
+              <FieldsetLegend>
+                <Heading level={HeadingLevels.H3}>
+                  {questions["is-maintained"]}
+                </Heading>
+              </FieldsetLegend>
             ) as React.ReactNode,
             radios: yesNoRadios,
           },


### PR DESCRIPTION
ITV-31 Update Garden step

# What?

It turns out that nothing on this page needed updating but I noticed that the spacing between the labels and the radio button lists needed increasing, so I spent more time than I'd care to admit to try and figure out what they should look like.. anyway, I made those changes and you can see the differences below:

### Before
<img src="https://user-images.githubusercontent.com/64883/89200319-be77d300-d5a7-11ea-908e-a6cde377cf24.png" width="400">


### After
<img src="https://user-images.githubusercontent.com/64883/89200258-a607b880-d5a7-11ea-81fb-eee98701bd17.png" width="450">