### PR TITLE
feat/ITV-32-tweak-question-in-repair

### DIFF
--- a/helpers/yesNoAppointmentRadios.ts
+++ b/helpers/yesNoAppointmentRadios.ts
@@ -1,0 +1,14 @@
+export default [
+  {
+    label: "Yes - appointment has been booked",
+    value: "yes booked",
+  },
+  {
+    label: "Yes - appointment has not been booked",
+    value: "not booked",
+  },
+  {
+    label: "No",
+    value: "no",
+  },
+];

--- a/steps/property-inspection/repairs.tsx
+++ b/steps/property-inspection/repairs.tsx
@@ -1,3 +1,4 @@
+import yesNoAppointmentRadios from "helpers/yesNoAppointmentRadios";
 import { FieldsetLegend, Link, Paragraph } from "lbh-frontend-react/components";
 import React from "react";
 import {
@@ -17,19 +18,18 @@ import { RadioButtons } from "../../components/RadioButtons";
 import { ReviewNotes } from "../../components/ReviewNotes";
 import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessStepDefinition from "../../helpers/ProcessStepDefinition";
-import yesNoRadios from "../../helpers/yesNoRadios";
 import { Notes } from "../../storage/DatabaseSchema";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
 const questions = {
-  "needs-repairs": "Are there any new repairs queries?",
+  "needs-repairs": "Are there any outstanding repairs queries?",
 };
 
 const step: ProcessStepDefinition<ProcessDatabaseSchema, "property"> = {
   title: PageTitles.Repairs,
-  heading: "New repairs",
+  heading: "Repairs",
   review: {
     rows: [
       {
@@ -94,7 +94,7 @@ const step: ProcessStepDefinition<ProcessDatabaseSchema, "property"> = {
             legend: (
               <FieldsetLegend>{questions["needs-repairs"]}</FieldsetLegend>
             ) as React.ReactNode,
-            radios: yesNoRadios,
+            radios: yesNoAppointmentRadios,
           },
           defaultValue: "",
           emptyValue: "",
@@ -124,7 +124,10 @@ const step: ProcessStepDefinition<ProcessDatabaseSchema, "property"> = {
           renderWhen(stepValues: {
             "needs-repairs"?: ComponentValue<ProcessDatabaseSchema, "property">;
           }): boolean {
-            return stepValues["needs-repairs"] === "yes";
+            return (
+              stepValues["needs-repairs"] === "yes booked" ||
+              stepValues["needs-repairs"] === "not booked"
+            );
           },
           defaultValue: [],
           emptyValue: [] as string[],
@@ -144,14 +147,17 @@ const step: ProcessStepDefinition<ProcessDatabaseSchema, "property"> = {
           Component: PostVisitActionInput,
           props: {
             label: {
-              value: "Add note about repairs if necessary",
+              value: "Add appointment date and any notes about repairs",
             },
             name: "repairs-notes",
           } as PostVisitActionInputProps,
           renderWhen(stepValues: {
             "needs-repairs"?: ComponentValue<ProcessDatabaseSchema, "property">;
           }): boolean {
-            return stepValues["needs-repairs"] === "yes";
+            return (
+              stepValues["needs-repairs"] === "yes booked" ||
+              stepValues["needs-repairs"] === "not booked"
+            );
           },
           defaultValue: [] as Notes,
           emptyValue: [] as Notes,


### PR DESCRIPTION
# What?

The repairs has been reworked so that includes a third radio button depending on a repairs appointment being booked/ not booked. 

# Notes

I have omitted the add date of appointment Text Input as it would require a schema change and can and the date can be added to the notes field. I have changed the hint text at the top of  the notes box to reflect this. 

The designs also include an "Add another repair" button. This functionality doesn't exist in THC and would require  a lot more work. We got around this in thc through notes being added by the HO in the box. 

https://balsamiq.cloud/sei56ua/piibaiu/r8EF4


